### PR TITLE
Add safeguards to inconsistent New Relic metrics

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -47,9 +47,9 @@ module.exports = (robot) ->
   robot.respond /newrelic\s(list|show)\sapp(s|lications)/i, (message) ->
     for application in robot.brain.data.newrelic.applications
       last_reported_at = moment(application.last_reported_at).fromNow()
-      responseTime = "#{application.application_summary.response_time} Ms"
-      throughput = "#{application.application_summary.throughput} Rpm"
-      errorRate = "#{application.application_summary.error_rate}% Errors"
+      responseTime = "#{application.application_summary?.response_time} Ms"
+      throughput = "#{application.application_summary?.throughput} Rpm"
+      errorRate = "#{application.application_summary?.error_rate}% Errors"
       message.send "(#{application.name}, #{application.health_status}) #{responseTime}, #{throughput}, #{errorRate} | #{last_reported_at} @ [https://rpm.newrelic.com/accounts/#{accountId}/applications/#{application.id}]"
 
   robot.respond /newrelic\s(list|show)\s(servers?|hosts?)/i, (message) ->


### PR DESCRIPTION
Some of the items in application_summary from the New Relic API are
optional and may or may not be present. If they are not present, the
script silently fails and does not show any information because it
encounters an error.

This makes the inconsistent keys optional. If you do not have these keys
present in your application_summary output from New Relic they will show
up as "Undefined" in the output which is preferable over the plugin not
working.
